### PR TITLE
Use XCFramework with CocoaPods

### DIFF
--- a/FreshchatSDK.podspec
+++ b/FreshchatSDK.podspec
@@ -8,11 +8,28 @@ Pod::Spec.new do |s|
                    			Modern messaging software that your sales and customer engagement teams will love.
                    			DESC
   s.homepage     		 = "https://www.freshchat.com"
-  s.license 	 		 = { :type => 'Commercial', :file => 'FreshchatSDK/LICENSE', :text => 'See https://www.freshworks.com/terms' }
+  s.license 	 		   = { :type => 'Commercial', :file => 'FreshchatSDK/LICENSE', :text => 'See https://www.freshworks.com/terms' }
   s.author       		 = { "Freshdesk" => "support@freshchat.com" }
-  s.social_media_url     = "https://twitter.com/freshchatapp"
+  s.social_media_url = "https://twitter.com/freshchatapp"
   s.platform     		 = :ios, "8.0"
   s.source       		 = { :git => "https://github.com/freshdesk/freshchat-ios.git", :tag => "v#{s.version}" }
-  s.vendored_frameworks = "FreshchatSDK.xcframework"
+
+  # Uses the legacy vendored library integration for integrating the FreshchatSDK (not compatible with Apple Silicon)
+  s.subspec 'VendoredLibrary' do |ss|
+    ss.source_files = "FreshchatSDK/*.{h,m}"
+    ss.preserve_paths = "FreshchatSDK/*"
+    ss.resources = "FreshchatSDK/FCResources.bundle", "FreshchatSDK/FreshchatModels.bundle", "FreshchatSDK/FCLocalization.bundle"
+    ss.ios.vendored_library = "FreshchatSDK/libFDFreshchatSDK.a"
+    ss.frameworks = "Foundation", "AVFoundation", "AudioToolbox", "CoreMedia", "CoreData", "ImageIO", "Photos", "SystemConfiguration", "Security", "WebKit", "CoreServices"
+    ss.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FreshchatSDK"' }
+    ss.requires_arc = true
+  end
+
+  # Uses the modern XCFramework bundle for integrating the FreshchatSDK (compatible with Apple Silicon)
+  s.subspec 'Default' do |ss|
+    ss.vendored_frameworks = "FreshchatSDK.xcframework"
+  end
+
+  s.default_subspec = 'Default'
 
 end

--- a/FreshchatSDK.podspec
+++ b/FreshchatSDK.podspec
@@ -13,12 +13,6 @@ Pod::Spec.new do |s|
   s.social_media_url     = "https://twitter.com/freshchatapp"
   s.platform     		 = :ios, "8.0"
   s.source       		 = { :git => "https://github.com/freshdesk/freshchat-ios.git", :tag => "v#{s.version}" }
-  s.source_files 		 = "FreshchatSDK/*.{h,m}"
-  s.preserve_paths 		 = "FreshchatSDK/*"
-  s.resources 			 = "FreshchatSDK/FCResources.bundle", "FreshchatSDK/FreshchatModels.bundle", "FreshchatSDK/FCLocalization.bundle"
-  s.ios.vendored_library = "FreshchatSDK/libFDFreshchatSDK.a"
-  s.frameworks 			 = "Foundation", "AVFoundation", "AudioToolbox", "CoreMedia", "CoreData", "ImageIO", "Photos", "SystemConfiguration", "Security", "WebKit", "CoreServices"
-  s.xcconfig       		 = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/FreshchatSDK"' }
-  s.requires_arc 		 = true
+  s.vendored_frameworks = "FreshchatSDK.xcframework"
 
 end

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ pod 'FreshchatSDK'
 end
 ```
 
+> Starting with version X.X.X, we deploy the framework using XCFrameworks bundle. If you cannot support this approach, you can instead integrate using the library directly by using the following in your **Podfile**:
+>
+> ```ruby
+> pod 'FreshchatSDK/VendoredLibrary'
+> ```
+
 #### Samples
 [Objective-C](https://github.com/freshdesk/freshchat-ios/tree/master/Sample/ObjectiveCSample)
 
@@ -22,7 +28,7 @@ end
 
 
 ## Documentation
-[Integration Guide](https://support.freshchat.com/support/solutions/articles/50000000048-freshchat-ios-sdk-integration-steps) 
+[Integration Guide](https://support.freshchat.com/support/solutions/articles/50000000048-freshchat-ios-sdk-integration-steps)
 
 [API docs](http://cocoadocs.org/docsets/FreshchatSDK)
 


### PR DESCRIPTION
👋 - This follows on to #136. It looks like #136 is focused on using the .xcframework bundle format for SPM alone, however XC Frameworks are the recommended distribution method for precompiled binaries since Xcode 11 so really we should be using the format beyond just SPM.

For example, in my project we integrate Freshchat using CocoaPods, but currently this library is a blocker for us using Apple silicon since the dependency does not include an arm64 architecture slice for the iOS Simulator. Using the xcframework fixes that. 

Please consider this patch in addition to your other changes. It would also be great if you could provide a timeline for releasing this change.  Thanks!